### PR TITLE
Add desktop file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,15 @@ https://github.com/manoeldesouza/zc
 
 ## Usage:
 
- sudo ./zyggy
+Launch from terminal:
+
+```shell
+$ sudo ./zyggy
+```
+
+Add an entry to your application launcher/desktop:
+
+```shell
+$ ln -s /opt/zyggy/zyggy ~/.local/bin/zyggy
+$ cp zyggy.desktop ~/.local/share/applications/zyggy.desktop
+```

--- a/zyggy.desktop
+++ b/zyggy.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Version=1.0
 Type=Application
-# Might also work if wet to False if `sudo` replaced with `gksudo` or `kdesu` or whatever equivalent ships with your DM/WM
+# Might also work if set to False if `sudo` replaced with `gksudo` or `kdesu` or whatever equivalent ships with your DM/WM
 Terminal=True
 Exec=sudo zyggy
 Name=Zyggy

--- a/zyggy.desktop
+++ b/zyggy.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Encoding=UTF-8
+Version=1.0
+Type=Application
+# Might also work if wet to False if `sudo` replaced with `gksudo` or `kdesu` or whatever equivalent ships with your DM/WM
+Terminal=true
+Exec=sudo /opt/zyggy/zyggy
+Name=Zyggy
+# Icon=

--- a/zyggy.desktop
+++ b/zyggy.desktop
@@ -3,7 +3,7 @@ Encoding=UTF-8
 Version=1.0
 Type=Application
 # Might also work if wet to False if `sudo` replaced with `gksudo` or `kdesu` or whatever equivalent ships with your DM/WM
-Terminal=true
-Exec=sudo /opt/zyggy/zyggy
+Terminal=True
+Exec=sudo zyggy
 Name=Zyggy
 # Icon=


### PR DESCRIPTION
Thanks for creating this tool. It's been helpful as i learn my way around ZFS. Sometimes, being able to see things graphically is just better for learning and discovery compared to the CLI.

In any event, I wanted to be able to launch the tool from my desktop app launcher (KDE).
I did not test on gnome, but the `.desktop` file should work.